### PR TITLE
feat(auth-code): add flag to dispatch event with the auth code

### DIFF
--- a/oauth2-authorization.js
+++ b/oauth2-authorization.js
@@ -98,7 +98,7 @@ export class OAuth2Authorization extends HTMLElement {
     this._state = settings.state || this.randomString(6);
     this._settings = settings;
     this._errored = false;
-    this._overrideCodeExchangeFlow = settings.overrideExchangeCodeFlow;
+    this._overrideExchangeCodeFlow = settings.overrideExchangeCodeFlow;
 
     try {
       this._sanityCheck(settings);
@@ -375,7 +375,7 @@ export class OAuth2Authorization extends HTMLElement {
 
   _processPopupData(e) {
     const tokenInfo = e.data;
-    const dontProcess = !this._overrideCodeExchangeFlow && (!tokenInfo || !tokenInfo.oauth2response);
+    const dontProcess = !this._overrideExchangeCodeFlow && (!tokenInfo || !tokenInfo.oauth2response);
     if (dontProcess) {
       // Possibly a message in the authorization info, not the popup.
       return;
@@ -411,7 +411,7 @@ export class OAuth2Authorization extends HTMLElement {
       // For authorization_code flow, the developer (user of the oauth2-authorization lib)
       // can pass a setting to override the code exchange flow. In this scenario,
       // we dispatch the auth code instead of exchanging the code for an access token.
-      if (this._overrideCodeExchangeFlow) {
+      if (this._overrideExchangeCodeFlow) {
         this._dispatchCodeResponse(tokenInfo);
       } else {
         this._exchangeCodeValue = tokenInfo.code;

--- a/oauth2-authorization.js
+++ b/oauth2-authorization.js
@@ -86,13 +86,13 @@ export class OAuth2Authorization extends HTMLElement {
    *
    * NOTE:
    * For authorization_code and any other grant type that may receive a code
-   * and exchange it for an access token (e.g. refresh_token), the settings object may have a property
+   * and exchange it for an access token, the settings object may have a property
    * "overrideExchangeCodeFlow" with a boolean value (true/false).
    *
    * The "overrideExchangeCodeFlow" property is a flag indicating that the developer wants to handle
    * exchanging the code for the token instead of having the module do it.
    *
-   * If "overrideExchangeCodeFlow" is set to true for the authorization_code and refresh_token grant types,
+   * If "overrideExchangeCodeFlow" is set to true for the authorization_code grant type,
    * we dispatch an "oauth2-code-response" event with the auth code.
    *
    * The user of this module should listen for this event and exchange the token for an access token on their end.
@@ -125,9 +125,6 @@ export class OAuth2Authorization extends HTMLElement {
         this._authorize(this._constructPopupUrl(settings, 'token'), settings);
         break;
       case 'authorization_code':
-        this._authorize(this._constructPopupUrl(settings, 'code'), settings);
-        break;
-      case 'refresh_token':
         this._authorize(this._constructPopupUrl(settings, 'code'), settings);
         break;
       case 'client_credentials':
@@ -415,7 +412,7 @@ export class OAuth2Authorization extends HTMLElement {
     } else if (this._type === 'implicit') {
       this._handleTokenInfo(tokenInfo);
       this.clear();
-    } else if (this._type === 'authorization_code' || this._type === 'refresh_token') {
+    } else if (this._type === 'authorization_code') {
       /**
        * For the authorization_code flow, the developer (user of the oauth2-authorization lib)
        * can pass a setting to override the code exchange flow. In this scenario,

--- a/oauth2-authorization.js
+++ b/oauth2-authorization.js
@@ -899,6 +899,7 @@ export class OAuth2Authorization extends HTMLElement {
   }
   /**
    * Dispatches an event with the authorization-code that propagates through the DOM.
+   * Closes the popup once the authorization code has been dispatched.
    *
    * @param {Object} detail The detail object.
    */

--- a/oauth2-authorization.js
+++ b/oauth2-authorization.js
@@ -909,6 +909,7 @@ export class OAuth2Authorization extends HTMLElement {
       detail
     });
     this.dispatchEvent(e);
+    this.clear();
   }
   /**
    * Dispatches an event with the token (e.g. access token) that propagates through the DOM.

--- a/oauth2-authorization.js
+++ b/oauth2-authorization.js
@@ -898,7 +898,7 @@ export class OAuth2Authorization extends HTMLElement {
     this.dispatchEvent(e);
   }
   /**
-   * Dispatches an event with the authorization-code that propagates through the DOM.
+   * Dispatches an event with the authorization code that propagates through the DOM.
    * Closes the popup once the authorization code has been dispatched.
    *
    * @param {Object} detail The detail object.

--- a/test/oauth2-authorization-code.test.js
+++ b/test/oauth2-authorization-code.test.js
@@ -50,6 +50,18 @@ describe('<oauth2-authorization>', () => {
         done(new Error(e.detail.message));
       });
     });
+
+    it('returns the auth "code" if the overrideExchangeCodeFlow is set', (done) => {
+      const paramsWithOverride = Object.assign({}, params, { overrideExchangeCodeFlow: true });
+
+      element.addEventListener('oauth2-code-response', () => {
+        done();
+      });
+      element.addEventListener('oauth2-error', (e) => {
+        done(new Error(e.detail.message));
+      });
+      element.authorize(paramsWithOverride);
+    });
   });
 
   describe('Password request', () => {


### PR DESCRIPTION
**Changes**
- Allow user of the oauth2-authorize to pass a **overrideExchangeCodeFlow** setting to authorize() to override **exchangeCode** for the **authorization_code** grant type.

**Why** 

This is useful for client-side apps that use this lib and can't go through the exchangeCode flow because of CORS for the /token endpoint.